### PR TITLE
Validate orgname length and case

### DIFF
--- a/templates/default/marketplace_setup.rb
+++ b/templates/default/marketplace_setup.rb
@@ -104,6 +104,12 @@ class MarketplaceSetup
           puts 'Your passwords did not match'
           redo
         end
+      elsif opt == 'organization'
+        orgname = ask('Please enter an orgname(Only lowercase):') do |o|
+          o.case = :down
+          o.validate = /\A[a-z0-9][a-z0-9_-]{0,254}\Z/
+        end
+        options[opt] = orgname
       else
         options[opt] = ask("Please enter your #{opt}:")
       end


### PR DESCRIPTION
* Validate orgname as https://github.com/chef/chef-server/blob/master/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_organization.erl#L192
* Auto convert the casing if orgname otherwise valid

Was able to input "surprise orgname" as the orgname and get this output at the end of the marketplace,
which was a surprise.

```
After you've logged in you'll want to download the Starter Kit:
https://ec2-54-86-11-89.compute-1.amazonaws.com/organizations/surprise/getting_started
```