### PR TITLE
Tweak setup wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ AWS
   <tr>
     <td><tt>['marketplace_image']['chef_server_version']</tt></td>
     <td>String</td>
-    <td>Which version of the Chef Server package to install</td>
+    <td>Which version of the Chef server package to install</td>
     <td><tt>latest</tt></td>
   </tr>
   <tr>
@@ -58,7 +58,7 @@ AWS
   <tr>
     <td><tt>['marketplace_image']['analytics_version']</tt></td>
     <td>String</td>
-    <td>The license count for the Chef Server</td>
+    <td>The license count for the Chef server</td>
     <td><tt>5</tt></td>
   </tr>
   <tr>

--- a/templates/default/marketplace_setup.rb
+++ b/templates/default/marketplace_setup.rb
@@ -4,7 +4,7 @@ require 'highline/import'
 require 'chef/json_compat'
 require 'ohai/system'
 
-add_command_under_category 'marketplace-setup', 'marketplace', 'Set up the Chef Server Marketplace Appliance', 2 do
+add_command_under_category 'marketplace-setup', 'marketplace', 'Set up the Chef server Marketplace Appliance', 2 do
   options = OpenStruct.new
 
   OptionParser.new do |opts|
@@ -145,7 +145,7 @@ class MarketplaceSetup
   end
 
   def reconfigure_chef_server
-    puts 'Please wait while we set up the Chef Server. This may take a few minutes to complete'
+    puts 'Please wait while we set up the Chef server. This may take a few minutes to complete.'
     run_command('chef-server-ctl reconfigure')
   end
 
@@ -193,9 +193,9 @@ class MarketplaceSetup
     fqdn = chef_running['private_chef']['lb']['api_fqdn']
     msg = [
       "\n\nYou're all set!\n",
-      "Next you'll want to log into the Chef Web Management console:",
+      "Next you'll want to log into the Chef management console:",
       "https://#{fqdn}/login\n",
-      'In order to use TLS we had to generate a self-signed certificate which',
+      'In order to use Transport Layer Security (TLS) we had to generate a self-signed certificate which',
       "might cause a warning in your browser, you can safely ignore it.\n",
       "Use your username '#{options.username}' instead of your email address to login\n",
       "After you've logged in you'll want to download the Starter Kit:",

--- a/templates/default/server-motd.erb
+++ b/templates/default/server-motd.erb
@@ -15,16 +15,16 @@ ________/\\\\\\\\\__/\\\________/\\\__/\\\\\\\\\\\\\\\__/\\\\\\\\\\\\\\\_
         _______\/////////__\///________\///__\///////////////__\///______________
 
 
-Welcome to the Chef Server Marketplace Appliance!
+Welcome to the Chef server Marketplace Appliance!
 
-If this your first time logging in you'll need to set up the Chef Server by
+If this your first time logging in you'll need to set up the Chef server by
 running the following command:
 
 sudo chef-server-ctl marketplace-setup
 
-If you need help, you can find documentation at https://docs.chef.io/aws_marketplace.html
+If you need help, you can find documentation at https://docs.chef.io/aws_marketplace.html.
 
-You can also contact our Support Team via email at <%= @support_email %>
+You can also email our support team at <%= @support_email %>.
 
 
 <% if @update_motd %>


### PR DESCRIPTION
I noted some changes that I felt should be made while I ran through the
setup process.

* “Chef Server” should be “Chef server”.
* I didn’t know what TLS stood for, so added the full term for others
who also don’t know. (From my background, it’s “thread-local storage”,
which didn’t make sense in this context :D)
* Simplified some wording; ended sentences with a period.
* Chef Web Management console => Chef management console