### PR TITLE
Adding helper methods and attributes to support smoke testing

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -29,6 +29,14 @@ module MarketplaceImageCookbook
       enabled_products.map { |p| p['name'] }
     end
 
+    def enabled_image_names
+      {
+        'aws'   => enabled_aws_image_names,
+        'azure' => enabled_azure_image_names,
+        'gce'   => enabled_gce_image_names
+      }
+    end
+
     def aws_products
       node['marketplace_image']['aws']['public']['aio']['products'] +
         node['marketplace_image']['aws']['public']['compliance']['products'] +
@@ -65,6 +73,10 @@ module MarketplaceImageCookbook
       products
     end
 
+    def enabled_aws_image_names
+      enabled_aws_products.map { |p| p['builder_options']['ami_name'] }
+    end
+
     def azure_products
       node['marketplace_image']['azure']['aio']['products'] +
         node['marketplace_image']['azure']['compliance']['products']
@@ -77,6 +89,10 @@ module MarketplaceImageCookbook
       products += node['marketplace_image']['azure']['compliance']['products'] if
         node['marketplace_image']['azure']['compliance']['enabled']
       products
+    end
+
+    def enabled_azure_image_names
+      enabled_azure_products.map { |p| p['builder_options']['user_image_label'] }
     end
 
     def enabled_azure_builders
@@ -99,6 +115,10 @@ module MarketplaceImageCookbook
       products += node['marketplace_image']['gce']['compliance']['products'] if
         node['marketplace_image']['gce']['compliance']['enabled']
       products
+    end
+
+    def enabled_gce_image_names
+      enabled_gce_products.map { |p| p['builder_options']['image_name'] }
     end
 
     def gce_builders

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'partnereng@chef.io'
 license 'Apache 2.0'
 description 'Installs/Configures marketplace_image'
 long_description 'Installs/Configures marketplace_image'
-version '0.4.1'
+version '0.4.2'
 
 depends 'fancy_execute'
 depends 'packman'

--- a/recipes/_publish.rb
+++ b/recipes/_publish.rb
@@ -54,3 +54,6 @@ end
 packer_template 'marketplace_images' do
   only enabled_builders
 end
+
+# Images that should have been built are saved to the node object for later smoke testing
+node.normal['marketplace_image']['published_images'] = enabled_image_names


### PR DESCRIPTION
Adding helper methods to collect the names of the images that should have been created by packer, and a statement in the _publish recipe to save those image names to the node object. This will be used by Delivery in the Smoke phase to see if the images were actually created.

/cc @ryancragun
