### PR TITLE
switch to using bintray for package downloads

### DIFF
--- a/templates/default/apt_upgrade.sh.erb
+++ b/templates/default/apt_upgrade.sh.erb
@@ -2,5 +2,8 @@
 
 sudo apt-get update
 sudo apt-get upgrade -y
-curl -s https://packagecloud.io/install/repositories/chef/stable/script.deb.sh | sudo bash
+sudo apt-get install apt-transport-https
+wget -qO - https://downloads.chef.io/packages-chef-io-public.key | sudo apt-key add -
+echo "deb https://packages.chef.io/stable-apt trusty main" | sudo tee -a /etc/apt/sources.list.d/chef-stable.list
+sudo apt-get update
 sudo apt-get install chef-marketplace -y

--- a/templates/default/yum_upgrade.sh.erb
+++ b/templates/default/yum_upgrade.sh.erb
@@ -2,6 +2,12 @@
 
 sudo yum update --disablerepo=chef-stable
 sudo yum upgrade -y --disablerepo=chef-stable
-
-curl -s https://packagecloud.io/install/repositories/chef/stable/script.rpm.sh | sudo bash
+sudo rpm --import https://downloads.chef.io/packages-chef-io-public.key
+cat <<EOL | sudo tee -a /etc/yum.repos.d/chef-stable.repo
+[chef-stable]
+name=chef-stable
+baseurl=https://packages.chef.io/stable-yum/el/\$releasever/\$basearch/
+gpgcheck=1
+enabled=1
+EOL
 sudo yum install chef-marketplace -y


### PR DESCRIPTION
Packagecloud will not be in use by end of month. This changes our packer processes to provision using bintray instead.

/cc @ryancragun 
