### PR TITLE
use bento/ubuntu-14.04 for vagrant box

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,7 +8,7 @@ platforms:
   - name: publish
     driver_plugin: vagrant
     driver_config:
-      box: opscode-ubuntu-14.04
+      box: bento/ubuntu-14.04
       customize:
         cpus: 2
         memory: 4096


### PR DESCRIPTION
`bento/ubuntu-14.04` is a registered box name that can
be downloaded from Hashicorp Atlas. Without a :box_url
for the outdated `opscode-ubuntu-14.04` in this project,
you must have had it loaded from another project and
registered locally. I don't, so I couldn't get this
project to work otherwise.

/cc @ryancragun