### PR TITLE
[CLOUD-338] Update marketplace_image for Chef 13

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'https://supermarket.chef.io'
 
 cookbook 'fancy_execute', git: 'https://github.com/irvingpop/fancy_execute.git'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
 gem 'berkshelf', '>= 4'

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #
 # Author:: Partner Engineering <partnereng@chef.io>
 # Copyright (c) 2016, Chef Software, Inc. <legal@chef.io>

--- a/attributes/apt.rb
+++ b/attributes/apt.rb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 default['apt']['compile_time_update'] = true

--- a/attributes/aws.rb
+++ b/attributes/aws.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 cred_dir = ::File.expand_path(::File.join('~', '.aws'))
 credential_file = ::File.join(cred_dir, 'credentials')
 

--- a/attributes/azure.rb
+++ b/attributes/azure.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 cred_dir = ::File.expand_path(::File.join('~', '.azure'))
 publish_settings_path = ::File.join(cred_dir, 'marketplace.publish_settings')
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,1 @@
+default['marketplace_image']['package_install_channel'] = 'stable'

--- a/attributes/gce.rb
+++ b/attributes/gce.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 default['marketplace_image']['gce']['aio']['enabled'] = false
 default['marketplace_image']['gce']['compliance']['enabled'] = false
 
@@ -16,7 +17,7 @@ default_marketplace_config = {
   'disable_outbound_traffic' => false,
   'license_count' => 25,
   'license_type' => 'fixed',
-  'free_node_count' => 5
+  'free_node_count' => 5,
 }
 
 gce_builder_config = {
@@ -37,7 +38,7 @@ default['marketplace_image']['gce']['aio']['products'] =
       ),
       'marketplace_config_options' => default_marketplace_config.merge(
         'license_count' => node_count
-      )
+      ),
     }
   end
 
@@ -52,6 +53,6 @@ default['marketplace_image']['gce']['compliance']['products'] =
         'license_count' => node_count,
         'role' => 'compliance',
         'doc_url' => 'https://docs.chef.io/install_compliance.html#google-marketplace'
-      )
+      ),
     }
   end

--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
@@ -12,7 +13,7 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "bento/ubuntu-14.04"
+  config.vm.box = 'bento/ubuntu-14.04'
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,
@@ -21,7 +22,7 @@ Vagrant.configure(2) do |config|
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  config.vm.network "private_network", ip: "192.168.33.10"
+  config.vm.network 'private_network', ip: '192.168.33.10'
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on
@@ -34,17 +35,17 @@ Vagrant.configure(2) do |config|
   # argument is a set of non-required options.
   config.vm.synced_folder '../../omnibus-marketplace', '/home/vagrant/omnibus-marketplace'
   config.vm.synced_folder '../', '/home/vagrant/marketplace_image'
-  
+
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.
   # Example for VirtualBox:
   #
-  config.vm.provider "virtualbox" do |vb|
-  #   # Display the VirtualBox GUI when booting the machine
-  #   vb.gui = true
-  #
+  config.vm.provider 'virtualbox' do |vb|
+    #   # Display the VirtualBox GUI when booting the machine
+    #   vb.gui = true
+    #
     # Customize the amount of memory on the VM:
-    vb.memory = "4096"
+    vb.memory = '4096'
   end
   #
   # View the documentation for the provider you are using for more

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #
 # Author:: Partner Engineering <partnereng@chef.io>
 # Copyright (c) 2016, Chef Software, Inc. <legal@chef.io>
@@ -33,7 +34,7 @@ module MarketplaceImageCookbook
       {
         'aws'   => enabled_aws_image_names,
         'azure' => enabled_azure_image_names,
-        'gce'   => enabled_gce_image_names
+        'gce'   => enabled_gce_image_names,
       }
     end
 
@@ -41,7 +42,7 @@ module MarketplaceImageCookbook
       node['marketplace_image']['aws']['ic']['compliance']['products'] +
         [
           node['marketplace_image']['aws']['public']['automate'],
-          node['marketplace_image']['aws']['public']['compliance']
+          node['marketplace_image']['aws']['public']['compliance'],
         ]
     end
 
@@ -126,8 +127,8 @@ module MarketplaceImageCookbook
     end
 
     def automate_builders
-      [ node['marketplace_image']['aws']['public']['automate']['name'],
-        node['marketplace_image']['azure']['automate']['name'],
+      [node['marketplace_image']['aws']['public']['automate']['name'],
+       node['marketplace_image']['azure']['automate']['name'],
       ]
     end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,11 +1,13 @@
+# frozen_string_literal: true
 name 'marketplace_image'
 maintainer 'Chef Partner Engineering'
 maintainer_email 'partnereng@chef.io'
 license 'Apache 2.0'
 description 'Installs/Configures marketplace_image'
 long_description 'Installs/Configures marketplace_image'
-version '0.4.2'
+version '0.5.0'
 
-depends 'fancy_execute'
+chef_version '>=12.19'
+
 depends 'packman'
-depends 'apt'
+depends 'fancy_execute', '~> 2.0'

--- a/recipes/_packer.rb
+++ b/recipes/_packer.rb
@@ -1,7 +1,14 @@
-include_recipe 'apt::default'
+# frozen_string_literal: true
+apt_update 'update' do
+  action :update
+  only_if { node['platform_family'] == 'debian' }
+end
+
 include_recipe 'packman::default'
 
-bash 'ulimit -n unlimited'
+bash 'ulimit -n unlimited' do
+  not_if { node['platform_family'] == 'debian' }
+end
 
 creds = data_bag_item('marketplace_image', 'publishing_credentials')
 

--- a/recipes/_publish.rb
+++ b/recipes/_publish.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 marketplace_products.each do |product|
   packer_builder product['name'] do
     options product['builder_options']
@@ -26,7 +28,7 @@ end
 
 packer_provisioner 'setup_apt_stable' do
   type 'shell'
-  source 'setup_apt_current.sh.erb'
+  source 'setup_apt_stable.sh.erb'
   only azure_builders
   not_if { use_current_repo? }
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 include_recipe 'marketplace_image::_packer'
 include_recipe 'marketplace_image::_publish'

--- a/recipes/dev.rb
+++ b/recipes/dev.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # this recipe is only meant to be run for development
 
 # write marketplace config


### PR DESCRIPTION
* Remove the dependency on the apt cookbook
* Use the built in apt resources
* Update fancy_execute to 2.0.0
* Fix a bug where we rendered the apt/current template repo when the repo
  should have been stable.
* Require chef 12.19 or higher
* Please chefstyle/rubocop