### PR TITLE
[CLOUD-552] Explicitly deprovision the azure linux agent

### DIFF
--- a/recipes/_publish.rb
+++ b/recipes/_publish.rb
@@ -77,6 +77,14 @@ packer_provisioner 'sudo rm -f /etc/chef-manage/manage.rb' do
   inline_shebang '/bin/bash'
 end
 
+packer_provisioner '/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync' do
+  execute_command "chmod +x {{ .Path }}; {{ .Vars }} sudo -E sh '{{ .Path }}'"
+  type 'shell'
+  inline true
+  inline_shebang '/bin/sh -x'
+  only azure_builders
+end
+
 packer_template 'marketplace_images' do
   only enabled_builders
 end


### PR DESCRIPTION
This needs to be done as the last step in a packer build, otherwise waagent will not run correctly on reprovisioning. We saw this manifest as cloud-init failing quietly when it was unable to complete a stage, resulting in inability to do password auth.

packer used to handle the deprovisioning step, but stopped:
https://github.com/hashicorp/packer/issues/4330#issuecomment-301664918

Signed-off-by: Yvonne Lam <yvonne@chef.io>