### PR TITLE
Allow channels and add version pinning support.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,21 +1,21 @@
 ---
+driver:
+  name: vagrant
+  box: bento/ubuntu-14.04
+  customize:
+    cpus: 2
+    memory: 4096
+
 provisioner:
   name: chef_zero
-  require_chef_omnibus: true
-  chef_omnibus_install_options: -d /tmp/vagrant-cache/vagrant_omnibus
+  product_name: chefdk
+  channel: current
   attributes:
     marketplace_image:
       package_install_channel: <%= ENV['CHANNEL'] || 'stable' %>
 
 platforms:
   - name: publish
-    driver_plugin: vagrant
-    driver_config:
-      box: bento/ubuntu-14.04
-      customize:
-        cpus: 2
-        memory: 4096
-
 suites:
   - name: azure_automate
     run_list: "marketplace_image::default"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,2 @@
 default['marketplace_image']['package_install_channel'] = 'stable'
+default['marketplace_image']['package_install_version'] = nil

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -126,8 +126,8 @@ module MarketplaceImageCookbook
       ]
     end
 
-    def use_current_repo?
-      node['marketplace_image']['package_install_channel'].casecmp('current') == 0
+    def use_repo?(repo)
+      node['marketplace_image']['package_install_channel'].casecmp(repo) == 0
     end
   end
 end

--- a/templates/default/install_marketplace_apt.sh.erb
+++ b/templates/default/install_marketplace_apt.sh.erb
@@ -3,4 +3,8 @@
 set -ex
 
 sudo apt-get update
+<% if @version %>
+sudo apt-get install chef-marketplace=<%= @version %>
+<% else %>
 sudo apt-get install chef-marketplace -y
+<% end %>

--- a/templates/default/install_marketplace_yum.sh.erb
+++ b/templates/default/install_marketplace_yum.sh.erb
@@ -4,4 +4,8 @@ set -ex
 
 sudo yum update -y
 sudo yum upgrade -y
+<% if @version %>
+sudo yum install chef-marketplace-<%= @version %> -y
+<% else %>
 sudo yum install chef-marketplace -y
+<% end %>

--- a/templates/default/prepare_automate_for_publishing.sh.erb
+++ b/templates/default/prepare_automate_for_publishing.sh.erb
@@ -3,5 +3,5 @@
 set -ex
 
 sudo chef-marketplace-ctl reconfigure
-sudo chef-marketplace-ctl upgrade --automate --server --override-outbound-traffic
+sudo chef-marketplace-ctl upgrade --automate --server --override-outbound-traffic --channel <%= node['marketplace_image']['package_install_channel'] %>
 sudo chef-marketplace-ctl prepare-for-publishing yes

--- a/templates/default/setup_apt_unstable.sh.erb
+++ b/templates/default/setup_apt_unstable.sh.erb
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -ex
+
+sudo rm -rf /etc/apt/sources.list.d/*chef*
+sudo mkdir -p /etc/apt/sources.list.d/
+sudo apt-get update
+sudo apt-get upgrade -y
+sudo apt-get install apt-transport-https -y
+sudo wget -qO - https://packages.chef.io/chef.asc | sudo apt-key add -
+echo "deb https://packages.chef.io/repos/apt/unstable trusty main" | sudo tee /etc/apt/sources.list.d/chef-unstable.list
+sudo apt-get update

--- a/templates/default/setup_yum_unstable.sh.erb
+++ b/templates/default/setup_yum_unstable.sh.erb
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -ex
+
+sudo rm -rf /etc/yum.repos.d/*chef*
+sudo rpm --import https://packages.chef.io/chef.asc
+sudo tee /etc/yum.repos.d/chef-unstable.repo <<EOL
+[chef-unstable]
+name=chef-unstable
+baseurl=https://packages.chef.io/repos/yum/unstable/el/7/\$basearch/
+gpgcheck=1
+enabled=1
+EOL
+sudo yum makecache fast


### PR DESCRIPTION
This allows us to test versions from unstable and specify specific apt or yum versions we wish to install. This is especially helpful for testing and debugging issues with the chef-marketplace packages.

Note documentation for these improvements will be included in a separate PR which encompasses additional documentation updates.  